### PR TITLE
Update row directive to call optional function for customization

### DIFF
--- a/smart-table-module/js/Directives.js
+++ b/smart-table-module/js/Directives.js
@@ -74,7 +74,14 @@
                 require: '^smartTable',
                 restrict: 'C',
                 link: function (scope, element, attr, ctrl) {
-
+                    
+                    var _config;
+                    if ((_config = scope.config) != null) {
+                        if (typeof _config.rowFunction === "function") {
+                            _config.rowFunction(scope, element, attr, ctrl);
+                        }
+                    }
+                    
                     element.bind('click', function () {
                         scope.$apply(function () {
                             ctrl.toggleSelection(scope.dataRow);


### PR DESCRIPTION
During `smartTableDataRow` linking, if `rowFunction` exists on the configuration, call it with the `link` arguments to achieve additional customization over row behavior and state.

Addresses #32.

Example:

**template.html**

``` html
<smart-table config="myConfig" columns="columns" rows="rows"></smart-table>
```

**controller.js**

``` javascript
scope.myConfig = {
    rowFunction: function (scope, element) {
        if (scope.$last || scope.dataRow.points > 10) {
            element.addClass('highlight');
        }
    }
}
```
