### PR TITLE
very crude fix for table width formatting. relocate filter row out of ta...

### DIFF
--- a/Smart-Table.debug.js
+++ b/Smart-Table.debug.js
@@ -638,7 +638,7 @@ angular.module("partials/editableCell.html", []).run(["$templateCache", function
 
 angular.module("partials/globalSearchCell.html", []).run(["$templateCache", function ($templateCache) {
     $templateCache.put("partials/globalSearchCell.html",
-        "<label>Search :</label>\n" +
+        "<label>Filter :</label>\n" +
             "<input type=\"text\" ng-model=\"searchValue\"/>");
 }]);
 
@@ -664,12 +664,12 @@ angular.module("partials/selectionCheckbox.html", []).run(["$templateCache", fun
 
 angular.module("partials/smartTable.html", []).run(["$templateCache", function ($templateCache) {
     $templateCache.put("partials/smartTable.html",
-        "<table class=\"smart-table\">\n" +
+        " <div>   <div class=\"smart-table-global-search-row\" ng-show=\"isGlobalSearchActivated\">\n" +
+        "        <div class=\"smart-table-global-search\" column-span=\"{{columns.length}}\" colspan=\"{{columnSpan}}\">\n" +
+        "        </div>\n" +
+        "    </div>\n" +
+        "<table  class=\"smart-table\">\n" +
             "    <thead>\n" +
-            "    <tr class=\"smart-table-global-search-row\" ng-show=\"isGlobalSearchActivated\">\n" +
-            "        <td class=\"smart-table-global-search\" column-span=\"{{columns.length}}\" colspan=\"{{columnSpan}}\">\n" +
-            "        </td>\n" +
-            "    </tr>\n" +
             "    <tr class=\"smart-table-header-row\">\n" +
             "        <th ng-repeat=\"column in columns\" ng-include=\"column.headerTemplateUrl\"\n" +
             "            class=\"smart-table-header-cell {{column.headerClass}}\" scope=\"col\">\n" +
@@ -689,7 +689,7 @@ angular.module("partials/smartTable.html", []).run(["$templateCache", function (
             "        </td>\n" +
             "    </tr>\n" +
             "    </tfoot>\n" +
-            "</table>\n" +
+            "</table>\n</div>" +
             "\n" +
             "\n" +
             "");
@@ -940,4 +940,3 @@ angular.module("partials/smartTable.html", []).run(["$templateCache", function (
             };
         }]);
 })(angular);
-


### PR DESCRIPTION
...ble

This is a super-crude fix (my apologies) but it works for me. I'm facing an issue with formatting of my table width. In order to fix this, I need to style my table with table-format:fixed. When I do this, the column widths are all taken from the first row of the table. Because I have Search enabled, the first row of the table is the Search row, and so my column styling is all ignored. This fix wraps the table in a div, then moves the Search row up a level so it's in the div, but outside of the table. Now my column width formatting is being correctly applied and I can style my table correctly.
