### PR TITLE
allow for HTML formatted cell contents

### DIFF
--- a/smart-table-module/js/Directives.js
+++ b/smart-table-module/js/Directives.js
@@ -164,7 +164,7 @@
                     scope.$watch('dataRow', function (value) {
                         scope.formatedValue = format(getter(row), column.formatFunction, column.formatParameter);
                         if (isSimpleCell === true) {
-                            element.text(scope.formatedValue);
+                            element.html(scope.formatedValue);
                         }
                     }, true);
 
@@ -173,7 +173,7 @@
                             element.html('<div editable-cell="" row="dataRow" column="column" type="column.type"></div>');
                             compile(element.contents())(scope);
                         } else {
-                            element.text(scope.formatedValue);
+                            element.html(scope.formatedValue);
                         }
                     }
 


### PR DESCRIPTION
If you have complex objects or images and want to show then in a smartTable you can use a formatFunction, however the formatted HTML is shown as plain tekst i.s.o. the rendered HTML. Changing element.text to element.html allows you to see the rendered HTML.

example: the cell data is a image URL and the formatFunction returns <img src="celldata"> we can now see the images in the table.
