### PR TITLE
don't trigger ng-dblclick when isEditMode is true

### DIFF
--- a/smart-table-module/partials/editableCell.html
+++ b/smart-table-module/partials/editableCell.html
@@ -1,4 +1,4 @@
-<div ng-dblclick="toggleEditMode($event)">
+<div ng-dblclick="isEditMode || toggleEditMode($event)">
     <span ng-hide="isEditMode">{{value | format:column.formatFunction:column.formatParameter}}</span>
 
     <form ng-submit="submit()" ng-show="isEditMode" name="myForm">


### PR DESCRIPTION
The problem:
When a user double clicks in an editableCell, the ng-dblclick is triggered, and replaces the new value with the old value. For type:number Chrome adds an up/down button which invites the user to double click.
The Solution:
A simple fix is to check if isEditMode is already true, before calling toggleEditMode($event)
