### PR TITLE
Fix for st-sort to support field name with spaces

### DIFF
--- a/src/stSort.js
+++ b/src/stSort.js
@@ -7,7 +7,7 @@
                 require: '^stTable',
                 link: function (scope, element, attr, ctrl) {
 
-                    var predicate = attr.stSort;
+                    var predicate = function(row){ return row[attr.stSort];};;
                     var getter = $parse(predicate);
                     var index = 0;
                     var states = ['descent', 'ascent', 'natural'];


### PR DESCRIPTION
Fixing st-sort predicate to be a getter function(supported by angularjs) to support field name with spaces, or dashes.
Was stuck on this issue on my own project. After read angular's doc, looks like it is possible to give $filter('orderBy') a so-called getter function to eliminate possible failures upon fields with special characters. And theoretically it won't affect any other parts that use dot annotation like injections in unit tests.
