### PR TITLE
Fix data already loaded (not triggering $watch) and the table redraws

### DIFF
--- a/src/stTable.js
+++ b/src/stTable.js
@@ -19,6 +19,20 @@
             var pipeAfterSafeCopy = true;
             var ctrl = this;
 
+            /**
+             * this will chain the operations of sorting and filtering based on the current table state (sort options, filtering, ect)
+             */
+            this.pipe = function pipe() {
+                var filtered = tableState.search.predicateObject ? filter(safeCopy, tableState.search.predicateObject) : safeCopy;
+                filtered = orderBy(filtered, tableState.sort.predicate, tableState.sort.reverse);
+                if (tableState.pagination.number !== undefined) {
+                    tableState.pagination.numberOfPages = filtered.length > 0 ? Math.ceil(filtered.length / tableState.pagination.number) : 1;
+                    filtered = filtered.slice(tableState.pagination.start, tableState.pagination.start + tableState.pagination.number);
+                }
+                displaySetter($scope, filtered);
+            };
+
+
             function copyRefs(src) {
                 return src ? [].concat(src) : [];
             }
@@ -32,10 +46,10 @@
 
             if ($attrs.stSafeSrc) {
                 safeGetter = $parse($attrs.stSafeSrc);
-                
+
                 if (safeCopy.length == 0)
                     updateSafeCopy();
-                
+
                 $scope.$watch(function () {
                     var safeSrc = safeGetter($scope);
                     return safeSrc ? safeSrc.length : 0;
@@ -80,18 +94,6 @@
                 this.pipe();
             };
 
-            /**
-             * this will chain the operations of sorting and filtering based on the current table state (sort options, filtering, ect)
-             */
-            this.pipe = function pipe() {
-                var filtered = tableState.search.predicateObject ? filter(safeCopy, tableState.search.predicateObject) : safeCopy;
-                filtered = orderBy(filtered, tableState.sort.predicate, tableState.sort.reverse);
-                if (tableState.pagination.number !== undefined) {
-                    tableState.pagination.numberOfPages = filtered.length > 0 ? Math.ceil(filtered.length / tableState.pagination.number) : 1;
-                    filtered = filtered.slice(tableState.pagination.start, tableState.pagination.start + tableState.pagination.number);
-                }
-                displaySetter($scope, filtered);
-            };
 
             /**
              * select a dataRow (it will add the attribute isSelected to the row object)


### PR DESCRIPTION
The condition happens if you are passing data from a parent scope and the then redraws the table. (Like if you change to another route and come back.
