### PR TITLE
Fix for #167

### DIFF
--- a/src/stPagination.js
+++ b/src/stPagination.js
@@ -38,6 +38,9 @@
                                 end = paginationState.numberOfPages + 1;
                                 start = Math.max(1, end - displayedPages);
                             }
+                            if (scope.numPages != paginationState.numberOfPages) {
+                                scope.selectPage(1);
+                            }
 
                             scope.pages = [];
                             scope.numPages = paginationState.numberOfPages;


### PR DESCRIPTION
A likely quickfix would be to select the first page only when the number of pages changes. 
Although this will not reset the page chosen whenever the modified data has the same number of pages as the safe copy, it would always display the table. The user can then reset the pages manually if desired.
