### PR TITLE
Make pagination AngularJS 1.3 compatible

### DIFF
--- a/src/stPagination.js
+++ b/src/stPagination.js
@@ -5,7 +5,7 @@
             return {
                 restrict: 'EA',
                 require: '^stTable',
-                scope: {},
+                scope: false,
                 template: '<div class="pagination" ng-if="pages.length >= 2"><ul class="pagination"><li ng-repeat="page in pages" ng-class="{active: page==currentPage}"><a ng-click="selectPage(page)">{{page}}</a></li></ul></div>',
                 replace: true,
                 link: function (scope, element, attrs, ctrl) {


### PR DESCRIPTION
The pagination does not work in angular 1.3 because pages is not passthru to the scope of the template.

This will work with angular 1.2.x and 1.3.
