### PR TITLE
Added force search key

### DIFF
--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -9,7 +9,7 @@ ng.module('smart-table')
                 var tableCtrl = ctrl;
                 var promise = null;
                 var throttle = attr.stDelay || 400;
-                var forcible = attrs.stEnter || true;
+                var forcible = attr.stEnter || true;
 
                 scope.$watch('predicate', function (newValue, oldValue) {
                     if (newValue !== oldValue) {


### PR DESCRIPTION
Added an even listener for the "enter" key presses, ignoring the throttle and forcing an immediate search.

I haven't added any tests. I also have noticed some bug: After typing to an input (stSearch) then immediately switching to another input to press enter causes the last input to be blank or be reverted to its last state.
