### PR TITLE
Add multi select function using Shift and Ctrl keys

### DIFF
--- a/src/stSelectRow.js
+++ b/src/stSelectRow.js
@@ -8,9 +8,9 @@ ng.module('smart-table')
             },
             link: function (scope, element, attr, ctrl) {
                 var mode = attr.stSelectMode || 'single';
-                element.bind('click', function () {
+                element.bind('click', function (eventType) {
                     scope.$apply(function () {
-                        ctrl.select(scope.row, mode);
+                        ctrl.select(scope.row, mode, eventType.shiftKey, eventType.ctrlKey);
                     });
                 });
 

--- a/src/stTable.js
+++ b/src/stTable.js
@@ -1,5 +1,5 @@
 ng.module('smart-table')
-    .controller('stTableController', ['$scope', '$parse', '$filter', '$attrs', function StTableController($scope, $parse, $filter, $attrs) {
+    .controller('stTableController', ['$scope', '$parse', '$filter', '$attrs', '$window', '$document', function StTableController($scope, $parse, $filter, $attrs, $window, $document) {
         var propertyName = $attrs.stTable;
         var displayGetter = $parse(propertyName);
         var displaySetter = displayGetter.assign;
@@ -99,11 +99,12 @@ ng.module('smart-table')
         /**
          * select a dataRow (it will add the attribute isSelected to the row object)
          * @param {Object} row - the row to select
-         * @param {String} [mode] - "single" or "multiple" (multiple by default)
+         * @param {String} [mode] - "single", "multiple" or "multiKey" (single by default)
          */
-        this.select = function select(row, mode) {
+        this.select = function select(row, mode, shiftKey, ctrlKey) {
             var rows = safeCopy;
             var index = rows.indexOf(row);
+            var i;
             if (index !== -1) {
                 if (mode === 'single') {
                     row.isSelected = row.isSelected !== true;
@@ -111,8 +112,50 @@ ng.module('smart-table')
                         lastSelected.isSelected = false;
                     }
                     lastSelected = row.isSelected === true ? row : undefined;
-                } else {
+                    
+                } else if (mode === 'multiple') {
                     rows[index].isSelected = !rows[index].isSelected;
+
+                } else if (mode === 'multiKey') {
+                    if (shiftKey) {
+                        /* Hack to remove selection created by the browser when using the shift key
+                         * The user will see this briefly flicker.
+                         */
+                        if ($window.getSelection) {
+                            $window.getSelection().removeAllRanges();
+                        } else if ($document.selection) {
+                            $document.selection.empty();
+                        }
+
+                        for (i = 0; i < rows.length; i++) {
+                            if (rows[i].isSelected)
+                                rows[i].isSelected = false;
+                        }
+                        
+                        if (lastSelected) {
+                            var start = Math.min(rows.indexOf(lastSelected), rows.indexOf(row));
+                            var end = Math.max(rows.indexOf(lastSelected), rows.indexOf(row));
+                            for (i = start; i <= end; i++) {
+                                rows[i].isSelected = true;
+                            }
+
+                        } else {
+                            row.isSelected = true;
+                            lastSelected = row;
+                        }
+
+                    } else if (ctrlKey) {
+                        row.isSelected = row.isSelected !== true;
+                        lastSelected = row.isSelected === true ? row : undefined;
+
+                    } else {
+                        for (i = 0; i < rows.length; i++) {
+                            if (rows[i] !== row && rows[i].isSelected)
+                                rows[i].isSelected = false;
+                        }
+                        row.isSelected = row.isSelected !== true;
+                        lastSelected = row.isSelected === true ? row : undefined;
+                    }
                 }
             }
         };


### PR DESCRIPTION
Add another option for the selection that allows multiple lines to be
selected using the Shift and Ctrl keys in the same way as in Windows.
I don't have a full development environment available to me on my
corporate workstation.  So this was developed by modifying the full
release smart-table-1.4.5.js file.  Then the changes were copied into
the individual source files.

I have tested this in IE9 and Chrome 36.0.1985.125.

You will probably want to do more testing than I am able to before
including it in the release.