### PR TITLE
Set package name to angular-smart-table

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "smart-table",
+    "name": "angular-smart-table",
     "version": "1.4.11",
     "homepage": "https://github.com/lorenzofox3/Smart-Table",
     "authors": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smart-table",
+  "name": "angular-smart-table",
   "version": "1.4.11",
   "description": "",
   "main": "dist/smart-table.debug.js",


### PR DESCRIPTION
As angular-smart-table is the package name registered in bower, I think it should be defined as is at least in bower.json.