### PR TITLE
feat(stConfig): add global configuration to `smart-table`

### DIFF
--- a/gulpFile.js
+++ b/gulpFile.js
@@ -9,7 +9,7 @@ var stylish = require('jshint-stylish');
 var packageJson = require('./package.json');
 var pluginList = ['stSearch', 'stSelectRow', 'stSort', 'stPagination', 'stPipe'];
 var disFolder = './dist/';
-var src = (['smart-table.module', 'stTable']).concat(pluginList).map(function (val) {
+var src = (['smart-table.module', 'stConfig', 'stTable']).concat(pluginList).map(function (val) {
     return 'src/' + val + '.js';
 });
 

--- a/src/stConfig.js
+++ b/src/stConfig.js
@@ -1,0 +1,19 @@
+ng.module('smart-table')
+  .constant('stConfig', {
+    pagination: {
+      template: 'template/smart-table/pagination.html',
+      itemsByPage: 10,
+      displayedPages: 5
+    },
+    search: {
+      delay: 400 // ms
+    },
+    select: {
+      mode: 'single',
+      selectedClass: 'st-selected'
+    },
+    sort: {
+      ascentClass: 'st-sort-ascent',
+      descentClass: 'st-sort-descent'
+    }
+  });

--- a/src/stPagination.js
+++ b/src/stPagination.js
@@ -1,5 +1,5 @@
 ng.module('smart-table')
-  .directive('stPagination', function () {
+  .directive('stPagination', ['stConfig', function (stConfig) {
     return {
       restrict: 'EA',
       require: '^stTable',
@@ -12,12 +12,12 @@ ng.module('smart-table')
         if (attrs.stTemplate) {
           return attrs.stTemplate;
         }
-        return 'template/smart-table/pagination.html';
+        return stConfig.pagination.template;
       },
       link: function (scope, element, attrs, ctrl) {
 
-        scope.stItemsByPage = scope.stItemsByPage ? +(scope.stItemsByPage) : 10;
-        scope.stDisplayedPages = scope.stDisplayedPages ? +(scope.stDisplayedPages) : 5;
+        scope.stItemsByPage = scope.stItemsByPage ? +(scope.stItemsByPage) : stConfig.pagination.itemsByPage;
+        scope.stDisplayedPages = scope.stDisplayedPages ? +(scope.stDisplayedPages) : stConfig.pagination.displayedPages;
 
         scope.currentPage = 1;
         scope.pages = [];
@@ -76,4 +76,4 @@ ng.module('smart-table')
         }
       }
     };
-  });
+  }]);

--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -1,5 +1,5 @@
 ng.module('smart-table')
-    .directive('stSearch', ['$timeout', function ($timeout) {
+    .directive('stSearch', ['stConfig', '$timeout', function (stConfig, $timeout) {
         return {
             require: '^stTable',
             scope: {
@@ -8,7 +8,7 @@ ng.module('smart-table')
             link: function (scope, element, attr, ctrl) {
                 var tableCtrl = ctrl;
                 var promise = null;
-                var throttle = attr.stDelay || 400;
+                var throttle = attr.stDelay || stConfig.search.delay;
 
                 scope.$watch('predicate', function (newValue, oldValue) {
                     if (newValue !== oldValue) {

--- a/src/stSelectRow.js
+++ b/src/stSelectRow.js
@@ -1,5 +1,5 @@
 ng.module('smart-table')
-  .directive('stSelectRow', function () {
+  .directive('stSelectRow', ['stConfig', function (stConfig) {
     return {
       restrict: 'A',
       require: '^stTable',
@@ -7,7 +7,7 @@ ng.module('smart-table')
         row: '=stSelectRow'
       },
       link: function (scope, element, attr, ctrl) {
-        var mode = attr.stSelectMode || 'single';
+        var mode = attr.stSelectMode || stConfig.select.mode;
         element.bind('click', function () {
           scope.$apply(function () {
             ctrl.select(scope.row, mode);
@@ -16,11 +16,11 @@ ng.module('smart-table')
 
         scope.$watch('row.isSelected', function (newValue) {
           if (newValue === true) {
-            element.addClass('st-selected');
+            element.addClass(stConfig.select.selectedClass);
           } else {
-            element.removeClass('st-selected');
+            element.removeClass(stConfig.select.selectedClass);
           }
         });
       }
     };
-  });
+  }]);

--- a/src/stSort.js
+++ b/src/stSort.js
@@ -1,5 +1,5 @@
 ng.module('smart-table')
-  .directive('stSort', ['$parse', function ($parse) {
+  .directive('stSort', ['stConfig', '$parse', function (stConfig, $parse) {
     return {
       restrict: 'A',
       require: '^stTable',
@@ -8,8 +8,8 @@ ng.module('smart-table')
         var predicate = attr.stSort;
         var getter = $parse(predicate);
         var index = 0;
-        var classAscent = attr.stClassAscent || 'st-sort-ascent';
-        var classDescent = attr.stClassDescent || 'st-sort-descent';
+        var classAscent = attr.stClassAscent || stConfig.sort.ascentClass;
+        var classDescent = attr.stClassDescent || stConfig.sort.descentClass;
         var stateClasses = [classAscent, classDescent];
         var sortDefault;
 
@@ -39,7 +39,7 @@ ng.module('smart-table')
         });
 
         if (sortDefault) {
-          index = attr.stSortDefault === 'reverse' ? 1 : 0;
+          index = sortDefault === 'reverse' ? 1 : 0;
           sort();
         }
 

--- a/src/stTable.js
+++ b/src/stTable.js
@@ -155,7 +155,7 @@ ng.module('smart-table')
     };
 
     /**
-     *User a different function than the angular orderBy
+     * Use a different function than the angular orderBy
      * @param sortFunctionName the name under which the custom order function is registered
      */
     this.setSortFunction = function setSortFunction(sortFunctionName) {

--- a/test/spec/stSearch.spec.js
+++ b/test/spec/stSearch.spec.js
@@ -16,6 +16,11 @@ describe('stSearch Directive', function () {
 
     beforeEach(module('smart-table'));
 
+    var stConfig;
+    beforeEach(inject(function (_stConfig_) {
+      stConfig = _stConfig_;
+    }));
+
     describe('string predicate', function () {
 
         beforeEach(inject(function ($compile, $rootScope) {
@@ -85,6 +90,72 @@ describe('stSearch Directive', function () {
                 {name: 'Renard', firstname: 'Olivier', age: 33},
                 {name: 'Faivre', firstname: 'Blandine', age: 44}
             ]);
+        }));
+
+        it('should throttle searching to 400ms by default', inject(function ($timeout) {
+            var ths = element.find('th');
+
+            var input = angular.element(ths[1].children[0]);
+            input[0].value = 're';
+            input.triggerHandler('input');
+
+            $timeout.flush(399);
+            trs = element.find('tr.test-filtered');
+            expect(trs.length).toBe(5);
+
+            $timeout.flush(1);
+            trs = element.find('tr.test-filtered');
+            expect(trs.length).toBe(4);
+        }));
+
+        it('should throttle searching by stConfig.search.delay', inject(function ($timeout, $rootScope, $compile) {
+            var oldDelay = stConfig.search.delay;
+            stConfig.search.delay = 845;
+
+            // Since we must set the stCofig before compiling, we must recompile after configuring a delay
+            scope = $rootScope.$new();
+            scope.rowCollection = [
+                {name: 'Renard', firstname: 'Laurent', age: 66},
+                {name: 'Francoise', firstname: 'Frere', age: 99},
+                {name: 'Renard', firstname: 'Olivier', age: 33},
+                {name: 'Leponge', firstname: 'Bob', age: 22},
+                {name: 'Faivre', firstname: 'Blandine', age: 44}
+            ];
+
+            var template = '<table st-table="rowCollection">' +
+                '<thead>' +
+                '<tr>' +
+                '<th><input st-search="\'name\'" /></th>' +
+                '<th><input st-search="" /></th>' +
+                '<th>age</th>' +
+                '</tr>' +
+                '</thead>' +
+                '<tbody>' +
+                '<tr class="test-filtered" ng-repeat="row in rowCollection">' +
+                '<td>{{row.name}}</td>' +
+                '<td>{{row.firstname}}</td>' +
+                '<td>{{row.age}}</td>' +
+                '</tr>' +
+                '</tbody>' +
+                '</table>';
+
+            element = $compile(template)(scope);
+            scope.$apply();
+            var ths = element.find('th');
+
+            var input = angular.element(ths[1].children[0]);
+            input[0].value = 're';
+            input.triggerHandler('input');
+
+            $timeout.flush(844);
+            trs = element.find('tr.test-filtered');
+            expect(trs.length).toBe(5);
+
+            $timeout.flush(1);
+            trs = element.find('tr.test-filtered');
+            expect(trs.length).toBe(4);
+
+            stConfig.search.delay = oldDelay;
         }));
     });
 

--- a/test/spec/stSelectRow.spec.js
+++ b/test/spec/stSelectRow.spec.js
@@ -10,6 +10,49 @@ describe('stSelectRow Directive', function () {
 
     beforeEach(module('smart-table'));
 
+    var stConfig;
+    beforeEach(inject(function (_stConfig_) {
+      stConfig = _stConfig_;
+    }));
+
+    // We need to do this here because we must compile the directive *after* configuring stConfig
+    it('should select more than one row when globally configured', inject(function ($rootScope, $compile) {
+        var oldMode = stConfig.select.mode;
+        stConfig.select.mode = 'multiple';
+
+
+        rootScope = $rootScope;
+        scope = $rootScope.$new();
+        rootScope.rowCollection = [
+            {name: 'Renard', firstname: 'Laurent', age: 66},
+            {name: 'Francoise', firstname: 'Frere', age: 99},
+            {name: 'Renard', firstname: 'Olivier', age: 33},
+            {name: 'Leponge', firstname: 'Bob', age: 22},
+            {name: 'Faivre', firstname: 'Blandine', age: 44}
+        ];
+
+        var template = '<table st-table="rowCollection">' +
+            '<tbody>' +
+            '<tr st-select-row="row" ng-repeat="row in rowCollection"></tr>' +
+            '</tbody>' +
+            '</table>';
+
+        element = $compile(template)(scope);
+
+        scope.$apply();
+
+
+        var trs = element.find('tr');
+        expect(trs.length).toBe(5);
+        angular.element(trs[3]).triggerHandler('click');
+        expect(scope.rowCollection[3].isSelected).toBe(true);
+        angular.element(trs[1]).triggerHandler('click');
+        expect(scope.rowCollection[1].isSelected).toBe(true);
+        expect(scope.rowCollection[3].isSelected).toBe(true);
+
+        stConfig.select.mode = oldMode;
+    }));
+
     describe('single mode', function () {
         beforeEach(inject(function ($compile, $rootScope) {
 
@@ -41,7 +84,7 @@ describe('stSelectRow Directive', function () {
             expect(scope.rowCollection[3].isSelected).toBe(true);
         });
 
-        it('should select one row only', function () {
+        it('should select one row only by default', function () {
             var trs = element.find('tr');
             expect(trs.length).toBe(5);
             angular.element(trs[3]).triggerHandler('click');
@@ -62,6 +105,23 @@ describe('stSelectRow Directive', function () {
             scope.rowCollection[2].isSelected = false;
             scope.$apply();
             expect(hasClass(tr[2], 'st-selected')).toBe(false);
+        });
+
+        it('should update the customized class name when isSelected property change', function () {
+            var oldClass = stConfig.select.selectedClass;
+            stConfig.select.selectedClass = 'custom-selected'
+
+            var tr = element.find('tr');
+            expect(hasClass(tr[2], 'custom-selected')).toBe(false);
+            scope.rowCollection[2].isSelected = true;
+            scope.$apply();
+            expect(hasClass(tr[2], 'custom-selected')).toBe(true);
+
+            scope.rowCollection[2].isSelected = false;
+            scope.$apply();
+            expect(hasClass(tr[2], 'custom-selected')).toBe(false);
+
+            stConfig.select.selectedClass = oldClass;
         });
     });
 

--- a/test/spec/stSort.spec.js
+++ b/test/spec/stSort.spec.js
@@ -32,295 +32,359 @@ describe('stSort Directive', function () {
     });
   }));
 
-  beforeEach(inject(function ($compile, $rootScope) {
+  describe('customized stConfig', function() {
 
-    rootScope = $rootScope;
-    scope = $rootScope.$new();
-    scope.rowCollection = [
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Renard', firstname: 'Olivier', age: 33},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Faivre', firstname: 'Blandine', age: 44}
-    ];
-    scope.getters = {
-      age: function ageGetter(row) {
-        return row.name.length;
-      },
-      name: function nameGetter(row) {
-        return row.name.length;
-      }
-    };
+    beforeEach(inject(function ($compile, $rootScope, stConfig) {
+      var oldAscentClass = stConfig.sort.ascentClass;
+      var oldDescentClass = stConfig.sort.descentClass;
+      stConfig.sort.ascentClass = 'custom-ascent';
+      stConfig.sort.descentClass = 'custom-descent';
 
-    var template = '<table dummy="" st-table="rowCollection">' +
-      '<thead>' +
-      '<tr><th st-sort="name">name</th>' +
-      '<th st-sort="firstname">firstname</th>' +
-      '<th st-sort="getters.age">age</th>' +
-      '<th st-sort="getters.name">age</th>' +
-      '</tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr class="test-row" ng-repeat="row in rowCollection">' +
-      '<td>{{row.name}}</td>' +
-      '<td>{{row.firstname}}</td>' +
-      '<td>{{row.age}}</td>' +
-      '</tr>' +
-      '</tbody>' +
-      '</table>';
+      rootScope = $rootScope;
+      scope = $rootScope.$new();
+      scope.rowCollection = [
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Faivre', firstname: 'Blandine', age: 44}
+      ];
+      scope.getters = {
+        age: function ageGetter(row) {
+          return row.name.length;
+        },
+        name: function nameGetter(row) {
+          return row.name.length;
+        }
+      };
 
-    element = $compile(template)(scope);
-    scope.$apply();
-  }));
+      var template = '<table dummy="" st-table="rowCollection">' +
+        '<thead>' +
+        '<tr><th st-sort="name">name</th>' +
+        '<th st-sort="firstname">firstname</th>' +
+        '<th st-sort="getters.age">age</th>' +
+        '<th st-sort="getters.name">age</th>' +
+        '</tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr class="test-row" ng-repeat="row in rowCollection">' +
+        '<td>{{row.name}}</td>' +
+        '<td>{{row.firstname}}</td>' +
+        '<td>{{row.age}}</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '</table>';
 
-  it('should sort by clicked header', function () {
-    var ths = element.find('th');
-    var actual;
-    angular.element(ths[1]).triggerHandler('click');
-    actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
-    expect(actual).toEqual([
-      {name: 'Faivre', firstname: 'Blandine', age: 44},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Renard', firstname: 'Olivier', age: 33}
-    ]);
+      element = $compile(template)(scope);
+      scope.$apply();
 
+
+      stConfig.sort.ascentClass = oldAscentClass;
+      stConfig.sort.descentClass = oldDescentClass;
+    }));
+
+    it('should customize classes for sorting', function() {
+      var ths = element.find('th');
+      angular.element(ths[1]).triggerHandler('click');
+      expect(hasClass(ths[1], 'custom-ascent')).toBe(true);
+      expect(hasClass(ths[1], 'custom-descent')).toBe(false);
+    });
   });
 
-  it('should revert on the second click', function () {
-    var ths = element.find('th');
-    var actual;
-    angular.element(ths[1]).triggerHandler('click');
-    angular.element(ths[1]).triggerHandler('click');
-    actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(true);
-    expect(actual).toEqual([
-      {name: 'Renard', firstname: 'Olivier', age: 33},
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Faivre', firstname: 'Blandine', age: 44}
-    ]);
+  describe('normal stConfig', function() {
 
+    beforeEach(inject(function ($compile, $rootScope) {
+
+      rootScope = $rootScope;
+      scope = $rootScope.$new();
+      scope.rowCollection = [
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Faivre', firstname: 'Blandine', age: 44}
+      ];
+      scope.getters = {
+        age: function ageGetter(row) {
+          return row.name.length;
+        },
+        name: function nameGetter(row) {
+          return row.name.length;
+        }
+      };
+
+      var template = '<table dummy="" st-table="rowCollection">' +
+        '<thead>' +
+        '<tr><th st-sort="name">name</th>' +
+        '<th st-sort="firstname">firstname</th>' +
+        '<th st-sort="getters.age">age</th>' +
+        '<th st-sort="getters.name">age</th>' +
+        '</tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr class="test-row" ng-repeat="row in rowCollection">' +
+        '<td>{{row.name}}</td>' +
+        '<td>{{row.firstname}}</td>' +
+        '<td>{{row.age}}</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '</table>';
+
+      element = $compile(template)(scope);
+      scope.$apply();
+    }));
+
+    it('should sort by clicked header', function () {
+      var ths = element.find('th');
+      var actual;
+      angular.element(ths[1]).triggerHandler('click');
+      actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
+      expect(actual).toEqual([
+        {name: 'Faivre', firstname: 'Blandine', age: 44},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Renard', firstname: 'Olivier', age: 33}
+      ]);
+
+    });
+
+    it('should revert on the second click', function () {
+      var ths = element.find('th');
+      var actual;
+      angular.element(ths[1]).triggerHandler('click');
+      angular.element(ths[1]).triggerHandler('click');
+      actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(true);
+      expect(actual).toEqual([
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Faivre', firstname: 'Blandine', age: 44}
+      ]);
+
+    });
+
+    it('should reset the sort state on the third call', function () {
+      var ths = element.find('th');
+      var actual;
+      angular.element(ths[1]).triggerHandler('click');
+      angular.element(ths[1]).triggerHandler('click');
+      tableState.sort = {
+        predicate: 'firstname',
+        reverse: true
+      };
+      tableState.pagination.start = 40;
+      angular.element(ths[1]).triggerHandler('click');
+      actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
+      expect(actual).toEqual([
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Faivre', firstname: 'Blandine', age: 44}
+      ]);
+      expect(tableState.sort).toEqual({});
+      expect(tableState.pagination.start).toEqual(0);
+
+    });
+
+    it('should support getter function as predicate', function () {
+      var ths = element.find('th');
+      var actual;
+      angular.element(ths[2]).triggerHandler('click');
+      actual = trToModel(element.find('tr.test-row'));
+      expect(actual).toEqual([
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Faivre', firstname: 'Blandine', age: 44},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Francoise', firstname: 'Frere', age: 99}
+      ]);
+
+    });
+
+    it('should switch from getter function to the other', function () {
+      var ths = element.find('th');
+      var actual;
+      angular.element(ths[2]).triggerHandler('click');
+      expect(hasClass(ths[2], 'st-sort-ascent')).toBe(true);
+      expect(hasClass(ths[3], 'st-sort-ascent')).toBe(false);
+
+      angular.element(ths[3]).triggerHandler('click');
+      expect(hasClass(ths[2], 'st-sort-ascent')).toBe(false);
+      expect(hasClass(ths[3], 'st-sort-ascent')).toBe(true);
+
+    });
+
+    it('should reset its class if table state has changed', function () {
+      var ths = element.find('th');
+      angular.element(ths[1]).triggerHandler('click');
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
+
+      tableState.sort = {
+        predicate: 'lastname'
+      };
+
+      scope.$apply();
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
+
+    });
+
+    it('should sort by default a column', inject(function ($compile) {
+      var template = '<table dummy="" st-table="rowCollection">' +
+        '<thead>' +
+        '<tr><th st-sort="name">name</th>' +
+        '<th st-sort-default="true" st-sort="firstname">firstname</th>' +
+        '<th st-sort="getters.age">age</th>' +
+        '</tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr class="test-row" ng-repeat="row in rowCollection">' +
+        '<td>{{row.name}}</td>' +
+        '<td>{{row.firstname}}</td>' +
+        '<td>{{row.age}}</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '</table>';
+
+      element = $compile(template)(scope);
+
+      scope.$apply();
+
+      var ths = element.find('th');
+      var actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
+      expect(actual).toEqual([
+        {name: 'Faivre', firstname: 'Blandine', age: 44},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Renard', firstname: 'Olivier', age: 33}
+      ]);
+    }));
+
+    it('should evaluate st sort default and consider a falsy value', inject(function ($compile) {
+
+      scope.column = {reverse: false};
+
+      var template = '<table dummy="" st-table="rowCollection">' +
+        '<thead>' +
+        '<tr><th st-sort="name">name</th>' +
+        '<th st-sort-default="column.reverse" st-sort="firstname">firstname</th>' +
+        '<th st-sort="getters.age">age</th>' +
+        '</tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr class="test-row" ng-repeat="row in rowCollection">' +
+        '<td>{{row.name}}</td>' +
+        '<td>{{row.firstname}}</td>' +
+        '<td>{{row.age}}</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '</table>';
+
+      element = $compile(template)(scope);
+
+      scope.$apply();
+
+      var ths = element.find('th');
+      var actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
+      expect(actual).toEqual([
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Faivre', firstname: 'Blandine', age: 44}
+      ]);
+
+    }));
+
+    it('should sort by default a column in reverse mode', inject(function ($compile) {
+      var template = '<table dummy="" st-table="rowCollection">' +
+        '<thead>' +
+        '<tr><th st-sort="name">name</th>' +
+        '<th st-sort-default="reverse" st-sort="firstname">firstname</th>' +
+        '<th st-sort="getters.age">age</th>' +
+        '</tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr class="test-row" ng-repeat="row in rowCollection">' +
+        '<td>{{row.name}}</td>' +
+        '<td>{{row.firstname}}</td>' +
+        '<td>{{row.age}}</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '</table>';
+
+      element = $compile(template)(scope);
+
+      scope.$apply();
+
+      var ths = element.find('th');
+      var actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(true);
+      expect(actual).toEqual([
+        {name: 'Renard', firstname: 'Olivier', age: 33},
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Faivre', firstname: 'Blandine', age: 44}
+      ]);
+    }));
+
+
+    it('should skip natural order', inject(function ($compile) {
+      var template = '<table dummy="" st-table="rowCollection">' +
+        '<thead>' +
+        '<tr><th>name</th>' +
+        '<th st-skip-natural="true" st-sort="firstname">firstname</th>' +
+        '<th>age</th>' +
+        '</tr>' +
+        '</thead>' +
+        '<tbody>' +
+        '<tr class="test-row" ng-repeat="row in rowCollection">' +
+        '<td>{{row.name}}</td>' +
+        '<td>{{row.firstname}}</td>' +
+        '<td>{{row.age}}</td>' +
+        '</tr>' +
+        '</tbody>' +
+        '</table>';
+
+      element = $compile(template)(scope);
+
+      scope.$apply();
+
+      var ths = element.find('th');
+      var th1 = angular.element(ths[1]);
+      th1.triggerHandler('click');
+      th1.triggerHandler('click');
+      th1.triggerHandler('click');
+      scope.$apply();
+      var actual = trToModel(element.find('tr.test-row'));
+      expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
+      expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
+      expect(actual).toEqual([
+        {name: 'Faivre', firstname: 'Blandine', age: 44},
+        {name: 'Leponge', firstname: 'Bob', age: 22},
+        {name: 'Francoise', firstname: 'Frere', age: 99},
+        {name: 'Renard', firstname: 'Laurent', age: 66},
+        {name: 'Renard', firstname: 'Olivier', age: 33}
+      ]);
+    }));
+    
   });
 
-  it('should reset the sort state on the third call', function () {
-    var ths = element.find('th');
-    var actual;
-    angular.element(ths[1]).triggerHandler('click');
-    angular.element(ths[1]).triggerHandler('click');
-    tableState.sort = {
-      predicate: 'firstname',
-      reverse: true
-    };
-    tableState.pagination.start = 40;
-    angular.element(ths[1]).triggerHandler('click');
-    actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
-    expect(actual).toEqual([
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Renard', firstname: 'Olivier', age: 33},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Faivre', firstname: 'Blandine', age: 44}
-    ]);
-    expect(tableState.sort).toEqual({});
-    expect(tableState.pagination.start).toEqual(0);
-
-  });
-
-  it('should support getter function as predicate', function () {
-    var ths = element.find('th');
-    var actual;
-    angular.element(ths[2]).triggerHandler('click');
-    actual = trToModel(element.find('tr.test-row'));
-    expect(actual).toEqual([
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Renard', firstname: 'Olivier', age: 33},
-      {name: 'Faivre', firstname: 'Blandine', age: 44},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Francoise', firstname: 'Frere', age: 99}
-    ]);
-
-  });
-
-  it('should switch from getter function to the other', function () {
-    var ths = element.find('th');
-    var actual;
-    angular.element(ths[2]).triggerHandler('click');
-    expect(hasClass(ths[2], 'st-sort-ascent')).toBe(true);
-    expect(hasClass(ths[3], 'st-sort-ascent')).toBe(false);
-
-    angular.element(ths[3]).triggerHandler('click');
-    expect(hasClass(ths[2], 'st-sort-ascent')).toBe(false);
-    expect(hasClass(ths[3], 'st-sort-ascent')).toBe(true);
-
-  });
-
-  it('should reset its class if table state has changed', function () {
-    var ths = element.find('th');
-    angular.element(ths[1]).triggerHandler('click');
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
-
-    tableState.sort = {
-      predicate: 'lastname'
-    };
-
-    scope.$apply();
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
-
-  });
-
-  it('should sort by default a column', inject(function ($compile) {
-    var template = '<table dummy="" st-table="rowCollection">' +
-      '<thead>' +
-      '<tr><th st-sort="name">name</th>' +
-      '<th st-sort-default="true" st-sort="firstname">firstname</th>' +
-      '<th st-sort="getters.age">age</th>' +
-      '</tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr class="test-row" ng-repeat="row in rowCollection">' +
-      '<td>{{row.name}}</td>' +
-      '<td>{{row.firstname}}</td>' +
-      '<td>{{row.age}}</td>' +
-      '</tr>' +
-      '</tbody>' +
-      '</table>';
-
-    element = $compile(template)(scope);
-
-    scope.$apply();
-
-    var ths = element.find('th');
-    var actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
-    expect(actual).toEqual([
-      {name: 'Faivre', firstname: 'Blandine', age: 44},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Renard', firstname: 'Olivier', age: 33}
-    ]);
-  }));
-
-  it('should evaluate st sort default and consider a falsy value', inject(function ($compile) {
-
-    scope.column = {reverse: false};
-
-    var template = '<table dummy="" st-table="rowCollection">' +
-      '<thead>' +
-      '<tr><th st-sort="name">name</th>' +
-      '<th st-sort-default="column.reverse" st-sort="firstname">firstname</th>' +
-      '<th st-sort="getters.age">age</th>' +
-      '</tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr class="test-row" ng-repeat="row in rowCollection">' +
-      '<td>{{row.name}}</td>' +
-      '<td>{{row.firstname}}</td>' +
-      '<td>{{row.age}}</td>' +
-      '</tr>' +
-      '</tbody>' +
-      '</table>';
-
-    element = $compile(template)(scope);
-
-    scope.$apply();
-
-    var ths = element.find('th');
-    var actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
-    expect(actual).toEqual([
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Renard', firstname: 'Olivier', age: 33},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Faivre', firstname: 'Blandine', age: 44}
-    ]);
-
-  }));
-
-  it('should sort by default a column in reverse mode', inject(function ($compile) {
-    var template = '<table dummy="" st-table="rowCollection">' +
-      '<thead>' +
-      '<tr><th st-sort="name">name</th>' +
-      '<th st-sort-default="reverse" st-sort="firstname">firstname</th>' +
-      '<th st-sort="getters.age">age</th>' +
-      '</tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr class="test-row" ng-repeat="row in rowCollection">' +
-      '<td>{{row.name}}</td>' +
-      '<td>{{row.firstname}}</td>' +
-      '<td>{{row.age}}</td>' +
-      '</tr>' +
-      '</tbody>' +
-      '</table>';
-
-    element = $compile(template)(scope);
-
-    scope.$apply();
-
-    var ths = element.find('th');
-    var actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(false);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(true);
-    expect(actual).toEqual([
-      {name: 'Renard', firstname: 'Olivier', age: 33},
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Faivre', firstname: 'Blandine', age: 44}
-    ]);
-  }));
-
-
-  it('should skip natural order', inject(function ($compile) {
-    var template = '<table dummy="" st-table="rowCollection">' +
-      '<thead>' +
-      '<tr><th>name</th>' +
-      '<th st-skip-natural="true" st-sort="firstname">firstname</th>' +
-      '<th>age</th>' +
-      '</tr>' +
-      '</thead>' +
-      '<tbody>' +
-      '<tr class="test-row" ng-repeat="row in rowCollection">' +
-      '<td>{{row.name}}</td>' +
-      '<td>{{row.firstname}}</td>' +
-      '<td>{{row.age}}</td>' +
-      '</tr>' +
-      '</tbody>' +
-      '</table>';
-
-    element = $compile(template)(scope);
-
-    scope.$apply();
-
-    var ths = element.find('th');
-    var th1 = angular.element(ths[1]);
-    th1.triggerHandler('click');
-    th1.triggerHandler('click');
-    th1.triggerHandler('click');
-    scope.$apply();
-    var actual = trToModel(element.find('tr.test-row'));
-    expect(hasClass(ths[1], 'st-sort-ascent')).toBe(true);
-    expect(hasClass(ths[1], 'st-sort-descent')).toBe(false);
-    expect(actual).toEqual([
-      {name: 'Faivre', firstname: 'Blandine', age: 44},
-      {name: 'Leponge', firstname: 'Bob', age: 22},
-      {name: 'Francoise', firstname: 'Frere', age: 99},
-      {name: 'Renard', firstname: 'Laurent', age: 66},
-      {name: 'Renard', firstname: 'Olivier', age: 33}
-    ]);
-  }));
 
 });


### PR DESCRIPTION
This adds configuration for each smart-table component. It's a common pattern found in modules (like ui-select).

It's a constant since you should only change stuff during the configuration of the Angular app.

The other option is to separate the configs into their own constants, since each of these things (sorting, pagination, etc) is an 'extension' of smart-table, and maybe you want the config constants to be more modular as well.

Let me know if that feels better (or if you like it as-is).

Potential TODO (but not now):
 1. Add default sort order (for all columns on all tables).

Thanks! :smile: 