### PR TITLE
Add filter comparator option to stSearch

### DIFF
--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -2,16 +2,20 @@ ng.module('smart-table')
   .directive('stSearch', ['stConfig', '$timeout', function (stConfig, $timeout) {
     return {
       require: '^stTable',
+      scope: {
+          stComparator: '&'
+      },
       link: function (scope, element, attr, ctrl) {
         var tableCtrl = ctrl;
         var promise = null;
         var throttle = attr.stDelay || stConfig.search.delay;
+        var comparator = scope.stComparator || false;
 
         attr.$observe('stSearch', function (newValue, oldValue) {
           var input = element[0].value;
           if (newValue !== oldValue && input) {
             ctrl.tableState().search = {};
-            tableCtrl.search(input, newValue);
+            tableCtrl.search(input, newValue, comparator());
           }
         });
 
@@ -33,7 +37,7 @@ ng.module('smart-table')
           }
 
           promise = $timeout(function () {
-            tableCtrl.search(evt.target.value, attr.stSearch || '');
+            tableCtrl.search(evt.target.value, attr.stSearch || '', comparator());
             promise = null;
           }, throttle);
         });

--- a/src/stTable.js
+++ b/src/stTable.js
@@ -74,7 +74,7 @@ ng.module('smart-table')
      * @param {String} input - the input string
      * @param {String} [predicate] - the property name against you want to check the match, otherwise it will search on all properties
      */
-    this.search = function search (input, predicate) {
+    this.search = function search (input, predicate, comparator) {
       var predicateObject = tableState.search.predicateObject || {};
       var prop = predicate ? predicate : '$';
 
@@ -86,16 +86,16 @@ ng.module('smart-table')
       }
       tableState.search.predicateObject = predicateObject;
       tableState.pagination.start = 0;
-      return this.pipe();
+      return this.pipe(comparator);
     };
 
     /**
      * this will chain the operations of sorting and filtering based on the current table state (sort options, filtering, ect)
      */
-    this.pipe = function pipe () {
+    this.pipe = function pipe (comparator) {
       var pagination = tableState.pagination;
       var output;
-      filtered = tableState.search.predicateObject ? filter(safeCopy, tableState.search.predicateObject) : safeCopy;
+      filtered = tableState.search.predicateObject ? filter(safeCopy, tableState.search.predicateObject, comparator) : safeCopy;
       if (tableState.sort.predicate) {
         filtered = orderBy(filtered, tableState.sort.predicate, tableState.sort.reverse);
       }


### PR DESCRIPTION
Added the st-comparator attribute option to the st-search directive to add a comparator function or a boolean value like in the angularjs filter function for a single element:

Comparator which is used in determining if the expected value (from the filter expression) and actual value (from the object in the array) should be considered a match.

Can be one of:
``` function(actual, expected) ```: The function will be given the object value and the predicate value to compare and should return true if both values should be considered equal.

``` true ```: A shorthand for ``` function(actual, expected) { return angular.equals(actual, expected)} ```. This is essentially strict comparison of expected and actual.

``` false|undefined ```: A short hand for a function which will look for a substring match in case insensitive way.

https://docs.angularjs.org/api/ng/filter/filter