### PR TITLE
added the option for a default search attribute

### DIFF
--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -8,7 +8,7 @@ ng.module('smart-table')
         var throttle = attr.stDelay || stConfig.search.delay;
 
         attr.$observe('stSearch', function (newValue, oldValue) {
-          var input = element[0].value;
+          var input = element[0].value || attr.stSearchDefault;
           if (newValue !== oldValue && input) {
             ctrl.tableState().search = {};
             tableCtrl.search(input, newValue);


### PR DESCRIPTION
I needed a way to populate the search field with a default search term that was passed through the URL.  For my use case, when clicking on a dashboard widget, I wanted to view a table that was pre-filtered by the context they clicked on (i.e. running virtual machines, stopped virtual machines, etc).

This can now be accomplished with this:

```
        <input st-search
               st-search-default="{{ query }}"
               ng-value="query">
```
