### PR TITLE
version text "latest" cannot be understood by webjars

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,10 +20,10 @@
         "tests"
     ],
     "dependencies": {
-        "angular": "latest"
+        "angular": ">0.0.1"
     },
     "devDependencies": {
-        "angular-mocks": "latest",
-        "jquery": "latest"
+        "angular-mocks": ">0.0.1",
+        "jquery": ">0.0.1"
     }
 }


### PR DESCRIPTION
Use a very old version number instead of "latest", otherwise webjars cannot deploy smart-table. #420