### PR TITLE
Proposal: stPagination - stCurrentPage attribute

### DIFF
--- a/src/stPagination.js
+++ b/src/stPagination.js
@@ -6,7 +6,8 @@ ng.module('smart-table')
       scope: {
         stItemsByPage: '=?',
         stDisplayedPages: '=?',
-        stPageChange: '&'
+        stPageChange: '&',
+        stCurrentPage: '=?'
       },
       templateUrl: function (element, attrs) {
         if (attrs.stTemplate) {
@@ -29,6 +30,7 @@ ng.module('smart-table')
           var i;
           var prevPage = scope.currentPage;
           scope.currentPage = Math.floor(paginationState.start / paginationState.number) + 1;
+		  scope.stCurrentPage = scope.currentPage;
 
           start = Math.max(start, scope.currentPage - Math.abs(Math.floor(scope.stDisplayedPages / 2)));
           end = start + scope.stDisplayedPages;
@@ -63,6 +65,15 @@ ng.module('smart-table')
         });
 
         scope.$watch('stDisplayedPages', redraw);
+		
+		scope.$watch('stCurrentPage', function (newValue, oldValue) {
+          if ((newValue !== oldValue) && (newValue > 0 && newValue <= scope.numPages)) {
+            scope.selectPage(newValue);
+          }
+          else {
+            scope.stCurrentPage = oldValue;
+          }
+        });
 
         //view -> table state
         scope.selectPage = function (page) {

--- a/test/spec/stPagination.spec.js
+++ b/test/spec/stPagination.spec.js
@@ -425,6 +425,89 @@ describe('stPagination directive', function () {
       expect(controllerMock.slice).toHaveBeenCalledWith(50, 10);
 
     });
+	
+  });
+
+  describe('st-current-page', function () {
+
+    it('should update st-current-page when page changes', function () {
+
+      spyOn(controllerMock, 'slice').andCallThrough();
+	  
+      var template = '<table st-table="rowCollection"><tfoot><tr><td id="pagination" st-pagination="" st-current-page="currentPage"></td></tr></tfoot></table>';
+      element = compile(template)(rootScope);
+
+      rootScope.$apply();
+
+      tableState.pagination = {
+        start: 1,
+        numberOfPages: 2,
+        number: 5
+      };
+
+      rootScope.$apply();
+
+      var pages = getPages();
+
+      angular.element(pages[1].children()[0]).triggerHandler('click');
+
+      rootScope.$apply();
+
+      expect(rootScope.currentPage).toBe(2);
+	  expect(controllerMock.slice).toHaveBeenCalledWith(10, 10);
+
+    });
+
+    it('should select a page when the bounded var to st-current-page changes', function () {
+
+      spyOn(controllerMock, 'slice').andCallThrough();
+	  
+      var template = '<table st-table="rowCollection"><tfoot><tr><td id="pagination" st-pagination="" st-current-page="currentPage"></td></tr></tfoot></table>';
+      element = compile(template)(rootScope);
+
+      rootScope.$apply();
+
+      tableState.pagination = {
+        start: 1,
+        numberOfPages: 2,
+        number: 5
+      };
+
+      rootScope.$apply();
+
+      rootScope.currentPage = 2;
+
+      rootScope.$apply();
+
+	  expect(controllerMock.slice).toHaveBeenCalledWith(10, 10);
+
+    });
+
+    it('should rollback the bounded var to its old value when the provided one is not correct', function () {
+
+      spyOn(controllerMock, 'slice').andCallThrough();
+	  
+      var template = '<table st-table="rowCollection"><tfoot><tr><td id="pagination" st-pagination="" st-current-page="currentPage"></td></tr></tfoot></table>';
+      element = compile(template)(rootScope);
+
+      rootScope.$apply();
+
+      tableState.pagination = {
+        start: 1,
+        numberOfPages: 2,
+        number: 5
+      };
+
+      rootScope.$apply();
+
+      rootScope.currentPage = 100;
+
+      rootScope.$apply();
+
+	  expect(rootScope.currentPage).toBe(1);
+	  expect(controllerMock.slice).toHaveBeenCalledWith(0, 10);
+
+    });
 
   });
 


### PR DESCRIPTION
I represent a company responsible for the tax administration of **several** spanish municipalities. Right now we are rewriting our old tax management application, *done in C++*, to a new and shining **Angular SPA**.
In the early phases of our development we tried several table components, like *ui-grid*, but yours ended being the one we truly needed. We enjoy it very much.

Our app lets the user have multiple *tasks* opened at the same time, each task having **several** reusable screens, and lets them move easily between them. Our screens store their *state* to communicate with other screens or simply to recover its previous state when the user returns.
Because of that, we need a very simple mechanism for always being aware of which one is the current page and also to change it *easily* programmatically via our controllers.

Basically I wrote a two-way data binding for the current page, a few tests and nothing more. This has been on testing for a week with no issues.

I know we could have ended writing a plugin for this, but after a long reunion, my superiors allowed me to code our solution and contribute to your project. Perhaps this is the first of many.