### PR TITLE
Added option to use literals/constants

### DIFF
--- a/dist/smart-table.js
+++ b/dist/smart-table.js
@@ -131,9 +131,14 @@ ng.module('smart-table')
     this.search = function search (input, predicate) {
       var predicateObject = tableState.search.predicateObject || {};
       var prop = predicate ? predicate : '$';
+      var checkParse = $parse(prop);
 
-      input = ng.isString(input) ? input.trim() : input;
-      $parse(prop).assign(predicateObject, input);
+      input = ng.isString(input) ? input.trim() : input;      
+      if(checkParse.assign){
+        checkParse.assign(predicateObject, input);      
+      }else{ 
+        predicateObject[prop] = input;    
+      }
       // to avoid to filter out null value
       if (!input) {
         deepDelete(predicateObject, prop);
@@ -269,9 +274,12 @@ ng.module('smart-table')
         scope.$watch(function () {
           return ctrl.tableState().search;
         }, function (newValue, oldValue) {
-          var predicateExpression = attr.stSearch || '$';
-          if (newValue.predicateObject && $parse(predicateExpression)(newValue.predicateObject) !== element[0].value) {
-            element[0].value = $parse(predicateExpression)(newValue.predicateObject) || '';
+          var predicateExpression = attr.stSearch || '$';          
+          if (newValue.predicateObject){
+              var checkParse = $parse(predicateExpression);
+              if(checkParse(newValue.predicateObject) !== element[0].value && !checkParse.literal && check.parseConstant){
+                element[0].value = $parse(predicateExpression)(newValue.predicateObject) || '';      
+              }
           }
         }, true);
 

--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -21,8 +21,11 @@ ng.module('smart-table')
           return ctrl.tableState().search;
         }, function (newValue, oldValue) {
           var predicateExpression = attr.stSearch || '$';
-          if (newValue.predicateObject && $parse(predicateExpression)(newValue.predicateObject) !== element[0].value) {
-            element[0].value = $parse(predicateExpression)(newValue.predicateObject) || '';
+          if (newValue.predicateObject){
+              var checkParse = $parse(predicateExpression);
+              if(checkParse(newValue.predicateObject) !== element[0].value && !checkParse.literal && check.parseConstant){
+                element[0].value = $parse(predicateExpression)(newValue.predicateObject) || '';      
+              }
           }
         }, true);
 

--- a/src/stTable.js
+++ b/src/stTable.js
@@ -92,9 +92,14 @@ ng.module('smart-table')
     this.search = function search (input, predicate) {
       var predicateObject = tableState.search.predicateObject || {};
       var prop = predicate ? predicate : '$';
+      var checkParse = $parse(prop);
 
-      input = ng.isString(input) ? input.trim() : input;
-      $parse(prop).assign(predicateObject, input);
+      input = ng.isString(input) ? input.trim() : input;      
+      if(checkParse.assign){
+        checkParse.assign(predicateObject, input);      
+      }else{ 
+        predicateObject[prop] = input;    
+      }
       // to avoid to filter out null value
       if (!input) {
         deepDelete(predicateObject, prop);


### PR DESCRIPTION
I find quite useful to use strings to send custom queries to remote servers when filtering rows, .e.g "'myfield<3'" , "'field like '%test%'"
It worked in previous versions when an independent scope was used for the stSearch directive, now the $parse(prop).assign is not defined for literals and constants so an exception is thrown.
May be this is not the best solution but it works for me.
