### PR TITLE
Pagination destroy recover

### DIFF
--- a/src/stPagination.js
+++ b/src/stPagination.js
@@ -75,6 +75,14 @@ ng.module('smart-table')
         if (!ctrl.tableState().pagination.number) {
           ctrl.slice(0, scope.stItemsByPage);
         }
+
+        scope.$on("$destroy", function() {
+            ctrl.tableState().pagination.start = 0;
+            ctrl.tableState().pagination.number = undefined;
+            ctrl.tableState().pagination.numberOfPages = undefined;
+            ctrl.pipe();
+        }); 
+
       }
     };
   }]);

--- a/test/spec/stPagination.spec.js
+++ b/test/spec/stPagination.spec.js
@@ -8,12 +8,17 @@ describe('stPagination directive', function () {
     slice: function (start, number) {
       tableState.pagination.start = start;
       tableState.pagination.number = number;
+    },
+
+    pipe: function () {
+
     }
   };
 
   function ControllerMock() {
     this.tableState = controllerMock.tableState;
     this.slice = controllerMock.slice;
+    this.pipe = controllerMock.pipe;
   }
 
   var tableState = {
@@ -522,6 +527,38 @@ describe('stPagination directive', function () {
 
       expect(pages.length).toBe(5);
       expect(rootScope.onPageChange.calls.length).toBe(1);
+    });
+
+  });
+
+  describe('handle destroy events', function () {
+ 
+    it('should show full table on destroy event', function () {
+
+      spyOn(controllerMock, 'tableState').andCallThrough();
+
+      tableState.pagination = {
+        start: 1,
+        numberOfPages: 4,
+        number: 10,
+        totalItemCount: 5
+      };
+
+      rootScope.paginationToggle = true;
+
+      var template = '<table st-table="rowCollection"><tfoot ng-if="paginationToggle"><tr><td id="pagination" st-pagination="" st-displayed-pages="5"></td></tr></tfoot></table>';
+      element = compile(template)(rootScope);
+
+      rootScope.$apply();
+
+      rootScope.paginationToggle = false;
+
+      rootScope.$apply();
+
+      expect(tableState.pagination.start).toEqual(0);
+      expect(tableState.pagination.totalItemCount).toEqual(5);
+      expect(tableState.pagination.numberOfPages).not.toBeDefined(); 
+      expect(tableState.pagination.number).not.toBeDefined(); 
     });
 
   });


### PR DESCRIPTION
The point of this change is to create tables that can have multiple modes (example: a reading and writing mode) and in one mode we can show pagination and in the other one show the entire table