### PR TITLE
fix #559: st-sort-default causes  already in progress error

### DIFF
--- a/src/stSort.js
+++ b/src/stSort.js
@@ -38,7 +38,7 @@ ng.module('smart-table')
             $timeout.cancel(promise);
           }
           if (throttle < 0) {
-            scope.$apply(func);
+            (scope.$$phase || scope.$root.$$phase) ? func() : scope.$apply(func);
           } else {
             promise = $timeout(func, throttle);
           }


### PR DESCRIPTION
The error acutally makes 2.1.5 broken. I use the solution of lambinator in the post http://stackoverflow.com/a/17114810/91813