### PR TITLE
added a noSortClass to be able to add spacing so that the header does…

### DIFF
--- a/src/stConfig.js
+++ b/src/stConfig.js
@@ -17,6 +17,7 @@ ng.module('smart-table')
       ascentClass: 'st-sort-ascent',
       descentClass: 'st-sort-descent',
       descendingFirst: false,
+      classNoSort: 'st-sort-nosort',
       skipNatural: false,
       delay:300
     },

--- a/src/stSort.js
+++ b/src/stSort.js
@@ -10,12 +10,15 @@ ng.module('smart-table')
         var index = 0;
         var classAscent = attr.stClassAscent || stConfig.sort.ascentClass;
         var classDescent = attr.stClassDescent || stConfig.sort.descentClass;
-        var stateClasses = [classAscent, classDescent];
+        var classNoSort = attr.stClassNosort || stConfig.sort.noSortClass;
+        var stateClasses = [classAscent, classDescent, classNoSort];
         var sortDefault;
         var skipNatural = attr.stSkipNatural !== undefined ? attr.stSkipNatural : stConfig.sort.skipNatural;
         var descendingFirst = attr.stDescendingFirst !== undefined ? attr.stDescendingFirst : stConfig.sort.descendingFirst;
         var promise = null;
         var throttle = attr.stDelay || stConfig.sort.delay;
+
+        element.addClass(classNoSort);
 
         if (attr.stSortDefault) {
           sortDefault = scope.$eval(attr.stSortDefault) !== undefined ? scope.$eval(attr.stSortDefault) : attr.stSortDefault;
@@ -69,11 +72,13 @@ ng.module('smart-table')
             index = 0;
             element
               .removeClass(classAscent)
-              .removeClass(classDescent);
+              .removeClass(classDescent)
+              .addClass(classNoSort);
           } else {
             index = newValue.reverse === true ? 2 : 1;
             element
               .removeClass(stateClasses[index % 2])
+              .removeClass(classNoSort)
               .addClass(stateClasses[index - 1]);
           }
         }, true);


### PR DESCRIPTION
… not jump

I had the issue that I could not easily define a css behaviour with smartTable when a sort column had no sort applied. Like this, when a sort was applied the header jumped (because of the added symbol). When adding a css class 
st-sort-nosort {
content: '\25BC';
    color:transparent;
}

This does not happen anymore... If you like the adaptation, please merge by commits!