### PR TITLE
"don't trim when I'm writing" fix

### DIFF
--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -21,7 +21,7 @@ ng.module('smart-table')
           return ctrl.tableState().search;
         }, function (newValue, oldValue) {
           var predicateExpression = attr.stSearch || '$';
-          if (newValue.predicateObject && $parse(predicateExpression)(newValue.predicateObject) !== element[0].value) {
+          if (newValue.predicateObject && $parse(predicateExpression)(newValue.predicateObject) !== element[0].value.trim()) {
             element[0].value = $parse(predicateExpression)(newValue.predicateObject) || '';
           }
         }, true);


### PR DESCRIPTION
When you are writing a multi words search, if you are not very fast it removes your last space