### PR TITLE
Add an event listener for remotely refreshing the table data

### DIFF
--- a/src/stTable.js
+++ b/src/stTable.js
@@ -74,6 +74,9 @@ ng.module('smart-table')
       });
     }
 
+    $scope.$on('callPipeFunction', function (event, data) {
+      ctrl.pipe();
+    });
     /**
      * sort the rows
      * @param {Function | String} predicate - function or string which will be used as predicate for the sorting

--- a/test/spec/stPipe.spec.js
+++ b/test/spec/stPipe.spec.js
@@ -48,4 +48,33 @@ describe('stPipe directive', function () {
             sort: {predicate: 'name', reverse: false}, search: {}, pagination: {start: 0, totalItemCount: 0}
         });
     }));
+
+    it('should call the pipe function with the current table state as argument on `callPipeFunction` event', inject(function ($timeout, $compile) {
+      var element;
+      var template = '<table st-pipe="customPipe" st-table="rowCollection">' +
+          '<thead>' +
+          '<tr><th st-sort="name">firstname</th>' +
+          '<th st-sort="lastname">lastname</th>' +
+          '<th st-sort="getters.age">age</th>' +
+          '</tr>' +
+          '</table>';
+      spyOn(scope, 'customPipe').andCallThrough();
+
+      element = $compile(template)(scope);
+
+      scope.$emit('callPipeFunction');
+
+      expect(firstArg).toBe(undefined);
+      expect(secondArg).toBe(undefined);
+
+      $timeout.flush();
+
+      expect(firstArg).toEqual({
+          sort : {  }, search : {  }, pagination : { start : 0, totalItemCount : 0 }
+      });
+
+      expect(secondArg.tableState()).toEqual({
+          sort : {  }, search : {  }, pagination : { start : 0, totalItemCount : 0 }
+      });
+    }));
 });


### PR DESCRIPTION
This pull request introduces the ability to call the pipe function remotely.

I've encountered a case where stSafeSrc was not enough. 

In my example, I was fetching data from a remote backend using stPipe in the table, but I also had a separate view on the same page, where I had an "editor". When I would edit something on that editor it would send a request to the backend, which may affect many entries in my collection. Therefore it would make sense to allow me to call the pipe function again to fetch a new collection from the backend.