### PR TITLE
Adjustments for Angular 1.6

### DIFF
--- a/dist/smart-table.js
+++ b/dist/smart-table.js
@@ -298,6 +298,7 @@ ng.module('smart-table')
             tableCtrl.search(evt.target.value, attr.stSearch || '');
             promise = null;
           }, throttle);
+          promise.catch(function(){});
         });
       }
     };
@@ -379,6 +380,7 @@ ng.module('smart-table')
             func();
           } else {
             promise = $timeout(func, throttle);
+            promise.catch(function(){});
           }
         }
 
@@ -518,7 +520,7 @@ ng.module('smart-table')
               pipePromise = $timeout(function () {
                 scope.stPipe(ctrl.tableState(), ctrl);
               }, config.pipe.delay);
-
+              pipePromise.catch(function(){});
               return pipePromise;
             }
           }


### PR DESCRIPTION
Catch timeout promise on cancel because it will throw an error in Angular 1.6