### PR TITLE
Adjustments for Angular 1.6 (src files)

### DIFF
--- a/src/stPipe.js
+++ b/src/stPipe.js
@@ -22,7 +22,9 @@ ng.module('smart-table')
               pipePromise = $timeout(function () {
                 scope.stPipe(ctrl.tableState(), ctrl);
               }, config.pipe.delay);
-
+              
+              pipePromise.catch(function(){});
+              
               return pipePromise;
             }
           }

--- a/src/stPipe.js
+++ b/src/stPipe.js
@@ -22,9 +22,7 @@ ng.module('smart-table')
               pipePromise = $timeout(function () {
                 scope.stPipe(ctrl.tableState(), ctrl);
               }, config.pipe.delay);
-              
               pipePromise.catch(function(){});
-              
               return pipePromise;
             }
           }

--- a/src/stSearch.js
+++ b/src/stSearch.js
@@ -37,6 +37,7 @@ ng.module('smart-table')
             tableCtrl.search(evt.target.value, attr.stSearch || '');
             promise = null;
           }, throttle);
+          promise.catch(function(){});
         });
       }
     };

--- a/src/stSort.js
+++ b/src/stSort.js
@@ -47,6 +47,7 @@ ng.module('smart-table')
             func();
           } else {
             promise = $timeout(func, throttle);
+            promise.catch(function(){});
           }
         }
 


### PR DESCRIPTION
Catch timeout promise on cancel because it will throw an error in Angular 1.6

This "error" is referring to the changelog for [1.6.0-rc.0 bracing-vortex (2016-10-26)](https://github.com/angular/angular.js/blob/master/CHANGELOG.md)

> c9dffd: report promises with non rejection callback
Unhandled rejected promises will be logged to $exceptionHandler

I recreated the error in this [plunker](https://plnkr.co/edit/bdUth1GsWDNAR4IhopBI?p=preview)
It is copy paste from the Pipe example from the documentation.
If you click a column header to sort the table too fast, the "$timeout" inside the code will be canceled and with the change for promises it will throw an error.
The catch that i added just prevent this.

Thought you can prevent the error for promises if you set `$qProvider.errorOnUnhandledRejections(false) `inside the config block from the angular module but i think this is not the right approach to disable this globaly for some people.