### PR TITLE
Handle Angular 1.6 error for stSort

### DIFF
--- a/src/stSort.js
+++ b/src/stSort.js
@@ -46,7 +46,9 @@ ng.module('smart-table')
           if (throttle < 0) {
             func();
           } else {
-            promise = $timeout(func, throttle);
+            promise = $timeout(function(){
+              func();
+            }, throttle);
           }
         }
 


### PR DESCRIPTION
Adjustments to prevent that the $timeout.cancle() will throw an error in certain cases (More information in #780).
Hopefully the final PR for this adjustment and I'm sorry that i spammed the PR section with this.