### PR TITLE
Fix Pagination Links not playing nice with ContentSecurityPolicy headers

### DIFF
--- a/src/smart-table.module.js
+++ b/src/smart-table.module.js
@@ -1,7 +1,7 @@
 ng.module('smart-table', []).run(['$templateCache', function ($templateCache) {
     $templateCache.put('template/smart-table/pagination.html',
         '<nav ng-if="numPages && pages.length >= 2"><ul class="pagination">' +
-        '<li ng-repeat="page in pages" ng-class="{active: page==currentPage}"><a href="javascript: void(0);" ng-click="selectPage(page)">{{page}}</a></li>' +
+        '<li ng-repeat="page in pages" ng-class="{active: page==currentPage}"><a href="#" ng-click="selectPage(page); $event.preventDefault(); $event.stopPropagation();">{{page}}</a></li>' +
         '</ul></nav>');
 }]);
 


### PR DESCRIPTION
Changed default pagination-template to generate links that are more
ContentSecurityPolicy Header compliant. This is done by using
just a hashmark instead of javascript:void(0) in the href attribute.

Also supress event propagation to prevent routers from doing something