### PR TITLE
Fix unexpected sort arrow appearance

### DIFF
--- a/src/stSort.js
+++ b/src/stSort.js
@@ -76,7 +76,7 @@ ng.module('smart-table')
         scope.$watch(function () {
           return ctrl.tableState().sort;
         }, function (newValue) {
-          if (newValue.predicate !== predicate) {
+          if (typeof(predicate) === 'undefined' || newValue.predicate !== predicate) {
             index = 0;
             element
               .removeClass(classAscent)


### PR DESCRIPTION
When `st-sort` is used with `ng-attr-` and the expression for `ng-attr-st-sort` yields `undefined`, (i.e. `ng-attr-st-sort='{{(someConditionToToggleSortability && 'true') || undefined}}'`, where `someConditionToToggleSortability` is `false`) the directive will be executed despite the `st-sort` attribute not actually being present in the DOM and the `predicate` variable will be `undefined`.

Additionally, `newValue` will simply have no `predicate` property at all. As a result, the condition was reducing to `undefined !== undefined`, which is, of course, `false`. This then causes the sorted-ascending arrow to appear on *every* column despite the fact that the items are still ordered naturally as, due to the absent `predicate`, `sort()` is never actually called.

Incidentally, if you do this but also provide `st-sort-default='reverse'`, the sorted-descending arrow appears, as you might expect.

This change simply tightens the condition such that the table will not visually report that it has been sorted if there is no sort predicate. 

This appears to be related to [AngularJS Issue 14575](https://github.com/angular/angular.js/issues/14575), and the AngularJS team has declined to alter this behavior. Evidently `ng-attr` will always add the attribute first, but during normalization it is removed, causing the behavior I've described. You can see where the removal occurs on [line 1756 in Angular's compile.js](https://github.com/angular/angular.js/blob/12cf994fccd7df6c2c2ba07d50b921ee80d62be7/src/ng/compile.js#L1756). The call to this function is on [line 3352 of the same file](https://github.com/angular/angular.js/blob/12cf994fccd7df6c2c2ba07d50b921ee80d62be7/src/ng/compile.js#L3352). This behavior seems to have been present since the compiler refactor in [1.0.0rc1](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#100rc1-moir%C3%A9-vision-2012-03-13) so I think trying to anticipate users that might attempt this sort of dynamic directive behavior might be prudent.