### PR TITLE
St table should add pagination by initial state

### DIFF
--- a/src/stTable.js
+++ b/src/stTable.js
@@ -3,7 +3,8 @@ ng.module('smart-table').controller('stTableController', [
   '$parse',
   '$filter',
   '$attrs',
-  function StTableController($scope, $parse, $filter, $attrs) {
+  'stConfig',
+  function StTableController($scope, $parse, $filter, $attrs, stConfig) {
     var propertyName = $attrs.stTable;
     var displayGetter = $parse(propertyName);
     var displaySetter = displayGetter.assign;
@@ -14,7 +15,7 @@ ng.module('smart-table').controller('stTableController', [
     var tableState = {
       sort: {},
       search: {},
-      pagination: { start: 0, totalItemCount: 0 }
+      pagination: { start: 0, totalItemCount: 0, number: stConfig.pagination.itemsByPage }
     };
     var filtered;
     var pipeAfterSafeCopy = true;


### PR DESCRIPTION
The problem: in case we want to paginate the data in the smart table, st-pagination must be loaded and call the slice function in the stTableController. because st-pagination depends on templateUrl to run its link function it's sometimes may take time for it to load, in this case the smart table can be loaded into the DOM before the link function of stPagination had time to run. loading all smart table into the DOM without any pagination will cause the browser to stuck in case there is too much data

by initial the pagination number to itemsByPage value, we make sure the data will be loaded always with initial pagination state.